### PR TITLE
Fix bug with navigating via location hash

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1398,10 +1398,8 @@ fromPageRect: page coordinates of the origin of the navigation
 historyTitle: title of history tiddler (defaults to $:/HistoryList)
 */
 exports.addToHistory = function(title,fromPageRect,historyTitle) {
-	if(historyTitle) {
-		var story = new $tw.Story({wiki: this, historyTitle: historyTitle});
-		story.addToHistory(title,fromPageRect);		
-	}
+	var story = new $tw.Story({wiki: this, historyTitle: historyTitle});
+	story.addToHistory(title,fromPageRect);		
 };
 
 /*
@@ -1412,10 +1410,8 @@ storyTitle: title of story tiddler (defaults to $:/StoryList)
 options: see story.js
 */
 exports.addToStory = function(title,fromTitle,storyTitle,options) {
-	if(storyTitle) {
-		var story = new $tw.Story({wiki: this, storyTitle: storyTitle});
-		story.addToStory(title,fromTitle,options);		
-	}
+	var story = new $tw.Story({wiki: this, storyTitle: storyTitle});
+	story.addToStory(title,fromTitle,options);		
 };
 
 /*


### PR DESCRIPTION
Introduced in 8159c4a8655c4c565baf6078074d1a791b5b81e5, the problem was that it is actually valid for storyTitle and/or historyTitle to be falsey in the Story constructor.